### PR TITLE
Remove HashWithIndifferentAccess altogether. 

### DIFF
--- a/lib/airtable/record.rb
+++ b/lib/airtable/record.rb
@@ -10,14 +10,33 @@ module Airtable
 
     # Return given attribute based on name or blank otherwise
     def [](name)
-      @attrs.has_key?(to_key(name)) ? @attrs[to_key(name)] : ""
+      if (name.is_a? Symbol)
+        name = @key_to_name[name]
+      end
+      @attrs.has_key?(name) ? @attrs[name] : ""
     end
 
     # Set the given attribute to value
     def []=(name, value)
-      @column_keys << name
-      @attrs[to_key(name)] = value
-      define_accessor(name) unless respond_to?(name)
+      if (name.is_a? Symbol)
+        if @key_to_name.has_key?(name)
+          name = @key_to_name[name]
+        else
+          # This is pretty fragile. It only works when the field name
+          # is exactly the same as the symbol (to_key(name) == name).
+          # In other cases, this will fail with 422 while saving to Airtable.
+          @key_to_name[name] = name.to_s
+          name = name.to_s
+          @column_names << name
+        end
+      else
+        if !@attrs.has_key?(name)
+          @column_names << name
+          @key_to_name[to_key(name)] = name
+        end
+      end
+      @attrs[name] = value
+      define_accessor_if_needed(name)
     end
 
     def inspect
@@ -29,18 +48,28 @@ module Airtable
 
     # Removes old and add new attributes for the record
     def override_attributes!(attrs={})
-      @column_keys = attrs.keys
-      @attrs = HashWithIndifferentAccess.new(Hash[attrs.map { |k, v| [ to_key(k), v ] }])
-      @attrs.map { |k, v| define_accessor(k) }
+      @column_names ||= [];
+      @key_to_name ||= Hash[]
+      attrs.keys.each do |k|
+        column_key = k.is_a?(Symbol) ? k : to_key(k)
+        # k.to_s fallback is fragile
+        column_name = k.is_a?(Symbol) ? @key_to_name[column_key] || k.to_s : k
+        if !@key_to_name.has_key?(column_key)
+          @column_names << column_name;
+          @key_to_name[column_key] = column_name;
+        end
+      end
+      @attrs = Hash[attrs.map {|k, v| [ k.is_a?(Symbol) ? @key_to_name[k] : k, v]} ]
+      @attrs.map { |k, v| define_accessor_if_needed(k) }
     end
 
     # Hash with keys based on airtable original column names
     def fields
-      HashWithIndifferentAccess.new(Hash[@column_keys.map { |k| [ k, @attrs[to_key(k)] ] }])
+      Hash[@attrs]
     end
 
     # Airtable will complain if we pass an 'id' as part of the request body.
-    def fields_for_update; fields.except(:id); end
+    def fields_for_update; fields.except('id'); end
 
     def method_missing(name, *args, &blk)
       # Accessor for attributes
@@ -68,8 +97,11 @@ module Airtable
         gsub(/\s/, '_').tr("-", "_").downcase
     end
 
-    def define_accessor(name)
-      self.class.send(:define_method, name) { @attrs[name] }
+    def define_accessor_if_needed(name)
+      key = to_key(name)
+      if !respond_to?(key)
+        self.class.send(:define_method, key) { @attrs[name] }
+      end
     end
 
   end # Record

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -10,7 +10,7 @@ describe Airtable do
     it "returns new columns in fields_for_update" do
       record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
       record[:website] = "http://sarahjaine.com"
-      record.fields_for_update.must_include(:website)
+      record.fields_for_update.must_include('website')
     end
 
     it "returns fields_for_update in original capitalization" do


### PR DESCRIPTION
This changes internal representation to be string field names instead of symbols returned by to_key. 

Using symbols is pretty fragile except for simple cases where the symbol exactly maps to field name. If a new record is created with a complex symbol (e.g. 'some_date'), it's impossible to know if the field name was actually 'some date', 'some-date' or 'some_date'. When saving to Airtable, the API will only accept the correct field name resulting in an error. Hopefully those kind of errors will be obvious and easy to address.

Addresses #5 