### PR TITLE
Custom Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+.DS_Store

--- a/airtable.gemspec
+++ b/airtable.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty"
+  spec.add_dependency "httparty", "~> 0.14.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.6.0"
-  spec.add_development_dependency "fakeweb", "~> 1.3"
+  spec.add_development_dependency "webmock", "~> 2.1.0"
   spec.add_development_dependency "activesupport", ">= 3.0"
 end

--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -1,12 +1,13 @@
 require 'httparty'
 require 'delegate'
-require "airtable/version"
+require 'airtable/version'
 require 'airtable/resource'
 require 'airtable/record'
 require 'airtable/record_set'
 require 'airtable/table'
 require 'airtable/client'
+require 'airtable/error'
 
-module Airtable
-  # Nothing for now
-end
+# module Airtable
+#   # Nothing for now
+# end

--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -7,7 +7,3 @@ require 'airtable/record_set'
 require 'airtable/table'
 require 'airtable/client'
 require 'airtable/error'
-
-# module Airtable
-#   # Nothing for now
-# end

--- a/lib/airtable/error.rb
+++ b/lib/airtable/error.rb
@@ -1,0 +1,15 @@
+
+module Airtable
+  class Error < StandardError
+
+    attr_reader :message, :type
+    # {"error"=>{"type"=>"UNKNOWN_COLUMN_NAME", "message"=>"Could not find fields foo"}}
+
+    def initialize(error_hash)
+      @message = error_hash['message']
+      @type = error_hash['type']
+      super(@message)
+    end
+
+  end
+end

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -59,5 +59,15 @@ describe Airtable do
         assert_equal "bar", record["foo"]
     end
 
+    it "should raise an error when the API returns an error" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
+        {"error"=>{"type"=>"UNKNOWN_COLUMN_NAME", "message"=>"Could not find fields foo"}}, :post, 422)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:foo => "bar")
+      assert_raises Airtable::Error do
+         table.create(record)
+      end
+    end
+
   end # describe Airtable
 end # Airtable

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,15 @@
 require 'airtable'
-require 'fakeweb'
+require 'webmock/minitest'
 require 'minitest/pride'
 require 'minitest/autorun'
 require 'active_support/core_ext/hash'
 
-# https://github.com/chrisk/fakeweb
-FakeWeb.allow_net_connect = false
+def stub_airtable_response!(url, response, method=:get, status=200)
 
-def stub_airtable_response!(url, response, method=:get)
-  FakeWeb.register_uri(method, url, :body => response.to_json, :content_type => "application/json")
+  stub_request(method, url)
+    .to_return(
+      body: response.to_json,
+      status: status,
+      headers: { 'Content-Type' =>  "application/json"}
+    )
 end


### PR DESCRIPTION
Adds custom Error class and raises errors when API returns an error instead of returning false. With test.

Maybe could use some more tests, but given the difficulty experienced in https://github.com/Airtable/airtable-ruby/issues/14 I think we need to stop swallowing API errors.

I also changed some test tooling (`fakeweb` hasn't been updated in a couple years).